### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -112,7 +112,7 @@ python-dateutil==2.8.2
 pytorch-lightning==1.5.10
 pytorch-ranger==0.1.1
 pytz==2022.2.1
-PyYAML==6.0
+PyYAML==6.0.1
 pyzmq==23.2.1
 qtconsole==5.3.1
 QtPy==2.2.0


### PR DESCRIPTION
PyYAML==6.0.0 installation is broken due to changes in Cython's recent 3.0 release. Version 6.0.1 solves this by pinning Cython's version to be <3.0.

See [https://github.com/yaml/pyyaml/issues/601] for the issue. It broke install on my machine.